### PR TITLE
Deploy to heroku using travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+sudo: true
+script: skip
+deploy:
+  provider: heroku
+  app: sack-live-score
+  api_key: $HEROKU_KEY
+  on:
+    repo: acf-sack/live-score
+    branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>lk.sack</groupId>
 	<artifactId>livescore</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<packaging>war</packaging>
+	<packaging>jar</packaging>
 	<name>livescore</name>
 	<description>Demo project for Spring Boot</description>
 


### PR DESCRIPTION
## Purpose 
The purpose of this PR is to fix #3 

The app will be live on https://sack-live-score.herokuapp.com/

## Goals
- Deploy the app to Heroku on each pull request

## Approach
- Change packaging from `war` to `jar`
- Create a new Heroku app
- Create `.travis.yml` file
- Add heroku deployment to travis configuration

## Learning 
https://docs.travis-ci.com/user/deployment/heroku/
