### PR TITLE
Update user-status endpoint to return a string

### DIFF
--- a/src/main/java/lk/sack/livescore/api/MainController.java
+++ b/src/main/java/lk/sack/livescore/api/MainController.java
@@ -63,11 +63,13 @@ public class MainController {
     }
 
     @PostMapping("/user-status")
-    public void checkUserStatus(HttpSession session) throws UnauthorizedUserException {
+    public String checkUserStatus(HttpSession session) throws UnauthorizedUserException {
         if (session.getAttribute("isAuthorizedUser") == null || session.getAttribute("isAuthorizedUser").equals(false)) {
-            String message = "Unauthorized attempt to update the score";
+            String message = "Unauthorized user";
             logger.warn(message);
             throw new UnauthorizedUserException(message);
+        }else{
+            return "Logged in";
         }
     }
 }


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #23 

## Goals
To make user-status endpoint work from ajax call

## Approach
Change the method to return a string

### Screenshots
N/A

##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Related PRs
N/A

## Test environment
JDK 1.8
ubuntu 19.10

## Learning

